### PR TITLE
Add only_args test-case

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,10 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        uses: php-actions/composer@private-repo-test
-        with:
-          ssh_key: ${{ secrets.SSH_KEY }}
-          ssh_key_pub: ${{ secrets.SSH_KEY_PUB }}
+        uses: RedaktionsNetzwerk-Deutschland/composer@bugfix/no-defaults
       - name: Dump autoload
         uses: RedaktionsNetzwerk-Deutschland/composer@bugfix/no-defaults
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,3 +13,8 @@ jobs:
         with:
           ssh_key: ${{ secrets.SSH_KEY }}
           ssh_key_pub: ${{ secrets.SSH_KEY_PUB }}
+      - name: Dump autoload
+        uses: RedaktionsNetzwerk-Deutschland/composer@bugfix/no-defaults
+        with:
+          command: dump-autoload
+          only_args: --no-dev --no-interaction --classmap-authoritative

--- a/composer.json
+++ b/composer.json
@@ -1,23 +1,7 @@
 {
 	"name": "php-actions/example-composer",
 	"description": "An example project that uses php-actions/composer",
-
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/php-actions/example-private-repo",
-			"options": {
-				"ssh2": {
-					"username": "git",
-					"pubkey_file": "./keys/deploy_rsa.pub",
-					"privkey_file": "./keys/deploy_rsa"
-				}
-			}
-		}
-	],
-
 	"require": {
-		"phpgt/webengine": "dev-master",
-		"php-actions/example-private-repo": "dev-master"
+		"phpgt/webengine": "dev-master"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4413274d9c9e9dd81474cec87e81555",
+    "content-hash": "70cd162f8aa316bb6d72d3d9fd6ab662",
     "packages": [
         {
             "name": "composer/semver",
@@ -167,29 +167,6 @@
                 "write_ini_file"
             ],
             "time": "2019-04-24T23:14:02+00:00"
-        },
-        {
-            "name": "php-actions/example-private-repo",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "git@github.com:php-actions/example-private-repo.git",
-                "reference": "e7f9c74d461b820aecaf5ed7a668e03951b692fe"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-actions/example-private-repo/zipball/e7f9c74d461b820aecaf5ed7a668e03951b692fe",
-                "reference": "e7f9c74d461b820aecaf5ed7a668e03951b692fe",
-                "shasum": ""
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "App\\": "./src/"
-                }
-            },
-            "description": "This repo is private, used within example-composer.",
-            "time": "2020-08-12T13:00:17+00:00"
         },
         {
             "name": "php-http/httplug",
@@ -727,16 +704,16 @@
         },
         {
             "name": "phpgt/dom",
-            "version": "v2.1.6",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PhpGt/Dom.git",
-                "reference": "fceb86cdb32e846178f75b7f9806d2b77635a879"
+                "reference": "26eb98925f1d5c8d39e4ddc7e2691ec63d0a99f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PhpGt/Dom/zipball/fceb86cdb32e846178f75b7f9806d2b77635a879",
-                "reference": "fceb86cdb32e846178f75b7f9806d2b77635a879",
+                "url": "https://api.github.com/repos/PhpGt/Dom/zipball/26eb98925f1d5c8d39e4ddc7e2691ec63d0a99f5",
+                "reference": "26eb98925f1d5c8d39e4ddc7e2691ec63d0a99f5",
                 "shasum": ""
             },
             "require": {
@@ -748,7 +725,7 @@
                 "psr/http-message": "1.*"
             },
             "require-dev": {
-                "phpunit/phpunit": "8.*"
+                "phpunit/phpunit": "9.*"
             },
             "type": "library",
             "autoload": {
@@ -804,7 +781,13 @@
                 }
             ],
             "description": "The modern DOM API for PHP 7 projects.",
-            "time": "2020-01-15T08:28:10+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/phpgt",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-01T11:06:01+00:00"
         },
         {
             "name": "phpgt/domtemplate",
@@ -1540,6 +1523,20 @@
                 "polyfill",
                 "portable"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-07-14T12:35:20+00:00"
         },
         {
@@ -1741,11 +1738,11 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "phpgt/webengine": 20,
-        "php-actions/example-private-repo": 20
+        "phpgt/webengine": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
In https://github.com/php-actions/composer/pull/12#issuecomment-687351807 @g105b said, that the new `only_args` implementation should be tested within this repository.
I'd to disable the private repo stuff because I'm missing the credentials ;-)

So the test is passing in my repository:
![CI](https://github.com/reflexxion/example-composer/workflows/CI/badge.svg?branch=test%2Fonly-args&event=push)