### PR TITLE
Update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,12 +9,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        uses: php-actions/composer@private-repo-test
+        uses: php-actions/composer@v2
         with:
           ssh_key: ${{ secrets.SSH_KEY }}
           ssh_key_pub: ${{ secrets.SSH_KEY_PUB }}
       - name: Dump autoload
-        uses: php-actions/composer@master
+        uses: php-actions/composer@v2
         with:
           command: dump-autoload
           only_args: --no-dev --no-interaction --classmap-authoritative


### PR DESCRIPTION
The `php-action/composer` readme shows snippets using `composer@v2`, but this example yaml had two different branches/tags used.  Looks like they can both be `v2` so should update for consistency and reduce confusion for action newcomers like myself. 😄